### PR TITLE
🚑 VIP 필드가 서버 오픈시 사라지는 문제에 대응

### DIFF
--- a/src/downTimeTimer.js
+++ b/src/downTimeTimer.js
@@ -34,7 +34,7 @@ const downTimeTracker = (version) => {
         const currentDate = currentTime.getDate();
         const startTimeDate = startTime.getDate();
 
-        const vipStatus = serverStatus.vip;
+        const vipStatus = serverStatus.vip ?? false;
 
         if (currentDate === startTimeDate) {
           if (vipStatus === true && vipMessageSent === false) {


### PR DESCRIPTION
<img width="485" height="233" alt="image" src="https://github.com/user-attachments/assets/b65734e3-941f-4cb7-b957-d66dbe9a0f39" />

서버 오픈후 VIP 모드로 켜지면 VIP:true필드가 있으나 , VIP 모드가 아닌 상태에서 켜지면 필드 자체가 없어짐

이를 대응하기 위해 VIP필드가 없으면 false를 반환하도록 함